### PR TITLE
README.md: Install MPI library before running distributed trainning

### DIFF
--- a/examples/bert_deepspeed/README.md
+++ b/examples/bert_deepspeed/README.md
@@ -12,6 +12,7 @@ conda create -n bert_deepspeed python==3.11
 conda activate bert_deepspeed
 git clone git@github.com:NascentCore/3k.git
 cd 3k/examples/bert_deepspeed
+apt install libopenmpi-dev
 pip install -r requirements.txt
 
 # Run 1 GPU locally, no deepspeed distributed.


### PR DESCRIPTION
README.md
`apt install libopenmpi-dev` before `pip install mpi4py`

## Issue
- [ ] No associated issue

## Test:
- [ ] No test needed
