### PR TITLE
Added dataset/ckpt/savedmodel PV related configs

### DIFF
--- a/examples/llama2/k8s/llama2_deepspeed_mpi.yaml
+++ b/examples/llama2/k8s/llama2_deepspeed_mpi.yaml
@@ -54,10 +54,6 @@ spec:
             - btl ^openlib
             - mca
             - mpi_warn_on_fork "0"
-            # All nodes where training processes run, including 1 master and 1+ workers. Please reach out to Glen to talk about this.
-            #- -H
-            # Node configurations, includong host names, slots, etc. Please reach out to Glen to talk about this.
-            #- --hostfile
             - python3
             - llama2_demo.py
             env:
@@ -76,7 +72,43 @@ spec:
           - name: llama2-training-deepspeed-mpi
             image: dockerhub.kubekey.local/kubesphereio/llama2_demo:2023-10-25
             imagePullPolicy: IfNotPresent
+            volumneMounts:
+            - mountPath: /workspace/dataset1
+              name: dataset1
+            - mountPath: /workspace/ds-experiments
+              name: ckpt-pv
+            - mountPath: /workspace/saved-model
+              name: saved-model-pv
             resources:
               limits:
                 # TODO(yzhao): 添加 IB 设备
                 nvidia.com/gpu: 2  # Number of GPUs required per replica.
+          volumes:
+          - name: dataset1
+            cephfs:
+              monitors:
+              - 10.233.33.169:6789
+              # CephFS' internal path
+              path: /readonly/hf/dataset
+              user: admin
+              secretRef:
+                name: ceph-secret
+              readOnly: true
+          - name: ckpt-pv
+            cephfs:
+              monitors:
+              - 10.233.33.169:6789
+              path: /readwrite/mvp-ckpt
+              user: admin
+              secretRef:
+                name: ceph-secret
+              readOnly: false
+          - name: saved-model-pv
+            cephfs:
+              monitors:
+              - 10.233.33.169:6789
+              path: /readwrite/mvp-saved-model
+              user: admin
+              secretRef:
+                name: ceph-secret
+              readOnly: false


### PR DESCRIPTION
# Describe your changes
- 去掉mpi -H和--hostfile之前注释掉的yaml code，因为mpirun on mpi-operator不需要这些信息。但机制还不确定。
- 在Worker部分增加mount和pv相关（类似template或placeholder）的信息。

@cairong-ai 关注一下Dockerfile和yaml文件本身是否OK，以及任何其他方面。
@congpeiqing 关注yaml文件是否OK，特别是需要mount/PV部分。

## Issue
- [ ] Check this box if this PR fixes an issue, and then paste the link below
- [ ] No associated issue

## Test:
- [ ] Check this box if this PR has tests
- [ ] No test needed
