### PR TITLE
Delete manager/pkg/storage/ceph.go

### DIFF
--- a/manager/pkg/storage/ceph.go
+++ b/manager/pkg/storage/ceph.go
@@ -1,3 +1,0 @@
-package storage
-
-// NO_TEST_NEEDED


### PR DESCRIPTION
Haven't been updated since 2 months ago, showing that it's not needed.

# Describe your changes

## Issue
- [ ] Check this box if this PR fixes an issue, and then paste the link below
- [ ] No associated issue

## Test:
- [ ] Check this box if this PR has tests
- [ ] No test needed
