### PR TITLE
add gpu/ib monitor

### DIFF
--- a/cli/conf/config.ini
+++ b/cli/conf/config.ini
@@ -6,6 +6,7 @@ package = packages/3k.tar.gz
 helm_apps = node-feature-discovery,gpu-operator,network-operator,kube-prometheus-stack
 yaml_apps = volcano-development,mpi-operator,infiniband-exporter
 ceph_nodes = worker1,worker2,worker3
+ib_nodes = worker1,worker2,worker3
 
 [registry]
 harbor_addr = https://dockerhub.kubekey.local

--- a/cli/conf/config.ini
+++ b/cli/conf/config.ini
@@ -4,7 +4,7 @@ kk_bin = bin/kk
 cluster_config = deploy/config-sample.yaml
 package = packages/3k.tar.gz
 helm_apps = node-feature-discovery,gpu-operator,network-operator,kube-prometheus-stack
-yaml_apps = volcano-development,mpi-operator
+yaml_apps = volcano-development,mpi-operator,infiniband-exporter
 ceph_nodes = worker1,worker2,worker3
 
 [registry]

--- a/cli/deploy/kubernetes.py
+++ b/cli/deploy/kubernetes.py
@@ -40,6 +40,11 @@ def install_operators():
                  "{}/deploy/values/{}.yaml".format(Conf.c.deploy.work_dir, app)
                  )
 
+    for node in Conf.c.deploy.ib_nodes.split(","):
+        retcode = (local["kubectl"]["get", "node", node, "--show-labels=true"] | grep["infiniband=available"]) & RETCODE
+        if retcode != 0:
+            kubectl_run("label", "node", node, "infiniband=available")
+
     for app in Conf.c.deploy.yaml_apps.split(","):
         print(colors.yellow | "===== [3kctl] install {} =====".format(app))
 

--- a/deployment/values/infiniband-exporter.yaml
+++ b/deployment/values/infiniband-exporter.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: infiniband-exporter
+  namespace: network-operator
+spec:
+  selector:
+    app: infiniband-exporter
+  ports:
+    - protocol: TCP
+      port: 9683
+      targetPort: 9683
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: infiniband-exporter
+  namespace: network-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: infiniband-exporter
+  template:
+    metadata:
+      labels:
+        app: infiniband-exporter
+    spec:
+      nodeSelector:
+        infiniband: available
+      containers:
+      - name: infiniband-exporter
+        image: dockerhub.kubekey.local/kubesphereio/infiniband-exporter:main
+        securityContext:
+          privileged: true
+          capabilities:
+            add: [ "IPC_LOCK" ]

--- a/deployment/values/kube-prometheus-stack.yaml
+++ b/deployment/values/kube-prometheus-stack.yaml
@@ -1,5 +1,5 @@
 kubeStateMetrics:
-  enabled: false
+  enabled: true
 
 grafana:
   enabled: true
@@ -55,6 +55,32 @@ prometheus:
     image:
       registry: dockerhub.kubekey.local/kubesphereio
       repository: prometheus
+    serviceMonitorSelectorNilUsesHelmValues: false
+    additionalScrapeConfigs:
+      - job_name: gpu-metrics
+        scrape_interval: 1s
+        metrics_path: /metrics
+        scheme: http
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+              - gpu-operator
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          action: replace
+          target_label: kubernetes_node
+      - job_name: infiniband-exporter
+        scrape_interval: 30s
+        metrics_path: /metrics
+        scheme: http
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+              - network-operator
+        static_configs:
+          - targets: ['infiniband-exporter.network-operator.svc.cluster.local:9683']
 
 thanosRuler:
   thanosRulerSpec:


### PR DESCRIPTION
### 背景：
    3k 平台部署后需要通过 grafana 查看 gpu、infiniband 监控指标

### 目标：
    通过开启相关监控配置，并与 prometheus 集成，实现在 grafana 中可查看 gpu、infiniband 监控 Dashboard

### 实施方法：
    1. 开启 kube-state-metrics 配置，开启后可在 Grafana - Dashboard 的 Kubernetes / Compute Resources 看到相关资源指标
    2. 安装 infiniband-exporter（https://github.com/guilbaults/infiniband-exporter）
    3. prometheus 配置中开启 dcgm-exportor、infiniband-exporter 集成配置
    4. 在 Grafana 界面 Dashboard 中导入开源的 GPU、InfiniBand Dashboard

### infiniband-exporter 镜像制作
```
FROM ubuntu:20.04
WORKDIR /infiniband-exporter
RUN apt-get update --fix-missing && apt-get install -y python3 pip infiniband-diags --fix-missing && \
    pip install prometheus-client==0.7.1
ADD https://github.com/guilbaults/infiniband-exporter/blob/master/infiniband-exporter.py ./
CMD python3 infiniband-exporter.py
```
 
### GPU、InfiniBand Dashboard 开源项目链接
https://grafana.com/grafana/dashboards/12239-nvidia-dcgm-exporter-dashboard/
https://grafana.com/grafana/dashboards/14992-infiniband-exporter-detailed/
