### PR TITLE
feat: add a ModelScope gpt pytorch example

### DIFF
--- a/examples/gpt3/ptjob_torchrun.yaml
+++ b/examples/gpt3/ptjob_torchrun.yaml
@@ -1,0 +1,20 @@
+apiVersion: "kubeflow.org/v1"
+kind: PyTorchJob
+metadata:
+  name: pytorch-torchrun
+  namespace: training-operator
+spec:
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: dockerhub.kubekey.local/kubesphereio/modelscope_gpt3:v002
+              imagePullPolicy: Always
+              command:
+                - "torchrun"
+                - "--nproc_per_node=1"
+                - "finetune_poetry.py"


### PR DESCRIPTION
# 背景
增加一个pytorchjob示例，训练[GPT3中文1.3B参数量文本生成模型](https://modelscope.cn/models/damo/nlp_gpt3_text-generation_1.3B/summary)

# 目标

# 其他信息
