### PR TITLE
cpod没上报GPU型号时，不应该给前端输送此类为空的数据

### DIFF
--- a/aiadmin/aiadmin-system/src/main/resources/mapper/system/CpodMainMapper.xml
+++ b/aiadmin/aiadmin-system/src/main/resources/mapper/system/CpodMainMapper.xml
@@ -48,6 +48,6 @@
 
     <select id="queryAllGpuType" resultMap="BaseResultMap">
         select distinct gpu_prod
-        from sys_cpod_main
+        from sys_cpod_main where `gpu_prod` != ""
     </select>
 </mapper>


### PR DESCRIPTION
# 背景

# 目标

# 其他信息
