### PR TITLE
update pytorch multinode base image to support ib network in k8s

### DIFF
--- a/devops/DOCKER.md
+++ b/devops/DOCKER.md
@@ -1,11 +1,12 @@
 # Docker
 
 Do the following to overcome the GFW:
+
 1. Build image on GCP
 2. Push the image onto Aliyun Singapore
 3. Pull image from China Mainland
 
-```
+```bash
 sudo apt install git docker.io
 sudo usermod -aG docker $USER
 newgrp docker

--- a/examples/gpt3/Dockerfile
+++ b/examples/gpt3/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.ap-southeast-1.aliyuncs.com/sxwl-ai/cuda_base:2023-10-23
+FROM registry.cn-beijing.aliyuncs.com/sxwl-ai/torch-base:v1
 WORKDIR /workspace
 # Put the layer that will not change frequently on it
-RUN python3 -m pip install  --no-cache-dir -U datasets==2.15.0 modelscope megatron_util jieba \
+RUN python3 -m pip install --no-cache-dir modelscope megatron_util jieba \
     -f https://modelscope.oss-cn-beijing.aliyuncs.com/releases/repo.html \
-    && pip3 install -U datasets
+    && pip3 install --no-cache-dir -U datasets
 COPY chinese-poetry-collection ./chinese-poetry-collection
 COPY nlp_gpt3_text-generation_1.3B ./nlp_gpt3_text-generation_1.3B
 COPY finetune_dureader.py finetune_poetry.py ./

--- a/examples/gpt3/README.md
+++ b/examples/gpt3/README.md
@@ -57,13 +57,13 @@ root@a2bd9b4ad983:/workspace# torchrun --nproc_per_node=1 finetune_poetry.py
 运行`ptjob_gpt3_1.3b_1h1g.yaml`单机单卡训练任务，此任务最小需要 32G 显存。
 如果单卡内存小于 32G 显存如 3090，则可以运行单机多卡的 pytorch job `ptjob_gpt3_1.3b_1h8g.yaml`。
 
-```
+```bash
 kubectl create -f ptjob_gpt3_1.3b_1h1g.yaml
 ```
 
 观察对应 pytorch job 和 worker 对应的 pod 是否运行成功
 
-```
+```bash
 $ kubectl -n training-operator get pytorchjob
 NAME               STATE     AGE
 pytorch-torchrun   Created   47s
@@ -75,7 +75,7 @@ pytorch-torchrun-worker-0            1/1     Running   0          21s   10.233.1
 
 pod 运行在 worker2，进入 对应 nvidia-driver 容器中，调用 nvidia-smi,观察 gpu 是否运行,
 
-```
+```bash
 
 $ kubectl exec -it nvidia-driver-daemonset-9l95r  -n gpu-operator  -- bash
 
@@ -116,10 +116,6 @@ pip install -i  https://pypi.tuna.tsinghua.edu.cn/simple tensorboard transformer
 pip install -U datasets
 
 # Step3: 准备代码、数据集和模型
-export http_proxy=http://squid:squid@214.2.5.239:13128
-export https_proxy=http://squid:squid@214.2.5.239:13128
-export no_proxy=localhost,127.0.0.1
-git clone https://github.com/NascentCore/3k.git
 cd 3k/examples/gpt3/
 
 git clone https://modelscope.cn/damo/nlp_gpt3_text-generation_1.3B.git
@@ -163,7 +159,7 @@ python -m torch.distributed.run  --nnodes=2  --nproc_per_node=8 --node-rank=1 --
 
 ```
 
-### 通过 pytorchjob 运行
+### 通过 pytorchjob 运行多机多卡
 
 ```bash
 kubectl create -f ptjob_gpt3_1.3b_2h16g.yaml

--- a/examples/gpt3/ptjob_gpt3_1.3b_2h16g.yaml
+++ b/examples/gpt3/ptjob_gpt3_1.3b_2h16g.yaml
@@ -18,14 +18,19 @@ spec:
         spec:
           containers:
             - name: pytorch
-              image: registry.cn-beijing.aliyuncs.com/sxwl-ai/modelscope_gpt3_2h16g4tp:latest
+              image: registry.cn-beijing.aliyuncs.com/sxwl-ai/modelscope_gpt3_2h16g4tp:v1
               imagePullPolicy: Always
               env:
               - name: NCCL_DEBUG
                 value: "INFO"
               - name: NCCL_NET
                 value: "IB"
+              - name: NCCL_IB_DISABLE
+                value: "0"
               resources:
+                requests:
+                  nvidia.com/gpu: 8
+                  rdma/rdma_shared_device_a: 1
                 limits:
                   nvidia.com/gpu: 8
                   rdma/rdma_shared_device_a: 1


### PR DESCRIPTION
### 背景

pytorch gpt3-1.3B 多节点训练任务在k8s无法使用IB网络，原因是基础镜像缺少IB相关工具集

### 目标

修复该问题

### 其他信息
> 描述这个 Pull Request 相关的其他信息
