### PR TITLE
feat: add ib check job

### DIFF
--- a/examples/IB/Dockerfile
+++ b/examples/IB/Dockerfile
@@ -1,0 +1,4 @@
+FROM registry.cn-beijing.aliyuncs.com/sxwl-ai/torch-base:v1
+WORKDIR /workspace
+RUN apt-get -y install ninja-build=1.10.0-1build1
+COPY test.py ./

--- a/examples/IB/README.md
+++ b/examples/IB/README.md
@@ -2,9 +2,9 @@
 
 InfiniBand verifications
 
-## ib_{read,write}_bw
+## ib\_{read,write}\_bw
 
-```
+```bash
 ssh -f <remote_ip> ib_read_bw
 ib_read_bw <remote_ip> -d <local_rdma_outlet> --report_gbits --run_infinitely
 
@@ -17,9 +17,10 @@ mst status -v
 
 ## ibping
 
-Node A 
-```
-ibstat 
+Node A
+
+```bash
+ibstat
 从ibstat的输出中任意选择一个CA以其Port，记录其Base lid
 
 CA和Port是上面选出的
@@ -27,7 +28,33 @@ ibping -S -C <CA> -P <Port>
 ```
 
 Node B
-```
+
+```bash
 ibping -L <前面记录的lid>
 ```
-注：以上命令皆需root用户执行（或sudo）
+
+注：以上命令皆需 root 用户执行（或 sudo）
+
+## 测试集群所有 IB 节点通信
+
+测试集群 IB 网卡通信是否正常，原理运行一个 elastic pytorchjob，该任务就是一个集合通信 all_reduce 调用，在每个节点
+上初始化一个标量 1，然后通过 all_reduce SUM 方法对所有节点标量 1 求和，打印一个等于节点数 n 的标量。通过 pod 之间的
+反亲和性设置，保证一个 ib 节点只运行一个 worker。如果集群所有带有 IB 网卡配置的节点能够正常通信，那么该 pytorchjob 将会
+变为`Succeeded`状态。
+
+编译镜像`docker build -t . registry.cn-beijing.aliyuncs.com/sxwl-ai/ib-check:latest`
+
+获取 IB 节点数量
+
+```bash
+IBNODE=$(kubectl get nodes --selector=feature.node.kubernetes.io/rdma.capable="true"
+| awk 'NR>1 {count++} END {print count}')
+```
+
+将 ib-check.yaml 中 IBNODE 替换并运行`kubectl create -f ib-check.yaml`
+
+观察校验任务 ib-check pytorchjob 的状态是否为`Succeeded`.
+
+```bash
+kubectl get pytorchjob
+```

--- a/examples/IB/all_reduce.py
+++ b/examples/IB/all_reduce.py
@@ -1,0 +1,16 @@
+import os
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+dist.init_process_group(backend="nccl")
+
+print("LOCAL_RANK:{}".format(os.environ["LOCAL_RANK"]))
+print("GLOBAL_RANK:{}".format(os.environ["RANK"]))
+print("GROUP_RANK:{}".format(os.environ["GROUP_RANK"]))
+print("ROLE_RANK:{}".format(os.environ["ROLE_RANK"]))
+print("LOCAL_WORLD_SIZE:{}".format(os.environ["LOCAL_WORLD_SIZE"]))
+
+tensor = torch.ones(1,device="cuda:{}".format(os.environ["LOCAL_RANK"]))
+dist.all_reduce(tensor,op=dist.ReduceOp.SUM)
+print('ALL_REDUCE_SUM_OF_ALL_WORKER:{}'.format(tensor))

--- a/examples/IB/ib-check.yaml
+++ b/examples/IB/ib-check.yaml
@@ -1,0 +1,52 @@
+apiVersion: "kubeflow.org/v1"
+kind: PyTorchJob
+metadata:
+  name: ib-check
+spec:
+  # 每个节点运行一个worker（pod）,每个worker只运行一个进程绑定一块GPU
+  nprocPerNode: "1"
+  elasticPolicy:
+    rdzvBackend: c10d
+  pytorchReplicaSpecs:
+    Worker:
+      replicas: ${IBNODE}
+      restartPolicy: OnFailure
+      template:
+        spec:
+          affinity:
+            # 保证一个节点一个worker,防止所有worker都调度到一个k8s node上
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - labelSelector:
+                  matchExpressions:
+                  - key: training.kubeflow.org/job-name
+                    operator: In
+                    values:
+                      - ib-check
+                topologyKey: kubernetes.io/hostname
+          containers:
+            - name: pytorch
+              image: registry.cn-beijing.aliyuncs.com/sxwl-ai/ib-check:latest
+              env:
+              - name: NCCL_DEBUG
+                value: "INFO"
+              - name: NCCL_NET
+                value: "IB"
+              - name: NCCL_IB_DISABLE
+                value: "0"
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  nvidia.com/gpu: 1
+                  rdma/rdma_shared_device_a: 1
+                limits:
+                  nvidia.com/gpu: 1
+                  rdma/rdma_shared_device_a: 1 
+              command:
+                - "torchrun"
+                - "--nnodes=${IBNODE}"
+                - "--nproc_per_node=1"
+                - "all_reduce.py"
+              securityContext:
+                capabilities:
+                  add: [ "IPC_LOCK" ]


### PR DESCRIPTION
### 背景

3k平台部署完之后，如果有节点有IB网卡，需要对IB网卡是否可用进行测试，目前的方法是手动在IB节点上运行一个基础pod，然后进入所有pod，运行一个基于NCCL IB的allreduce demo,观察日志是否有`Use IB Network`输出，比较繁琐 。

### 目标

简化测试流程，原理是在所有IB节点（标签feature.node.kubernetes.io/rdma.capable="true）上运行一个pytorch elastic job，通过pod反亲和保证每个IB节点只运行一个pod(worker)，如果job能够successed，则集群所有IB节点可用

### 其他信息
> 描述这个 Pull Request 相关的其他信息
