### PR TITLE
ci: skip e2e test for go unit test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,24 +5,25 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-
   build_and_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Set up Go
-      uses: actions/setup-go@v4
-      with:
-        go-version: '1.21.1'
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.21.1"
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build -v ./...
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: |
+          # shellcheck disable=SC2046
+          go test -v $(go list ./... | grep -v "/e2e")


### PR DESCRIPTION
### 背景
golang 单元测试无法通过。引入e2e之后，由于e2e是基于go test 单元测试风格，所以`go test ./...`也会测试e2e目录的端到端测试，但是由于e2e需要kubernetes集群，所以无法成功

### 目标
单元测试忽略e2e目录

### 其他信息
> 描述这个 Pull Request 相关的其他信息
