### PR TITLE
出现job正常上报，但模型url没能正常上报时的异常情况下，在进行job状态产讯时需要对模型url做非空判断

### DIFF
--- a/aiadmin/aiadmin-system/src/main/java/nascentcore/ai/modules/system/rest/UserJobController.java
+++ b/aiadmin/aiadmin-system/src/main/java/nascentcore/ai/modules/system/rest/UserJobController.java
@@ -77,7 +77,9 @@ public class UserJobController {
                 FileurlQueryCriteria fileurlQueryCriteria = new FileurlQueryCriteria();
                 fileurlQueryCriteria.setJobName(jobId);
                 List<Fileurl> fileurlList = fileurlService.queryAll(fileurlQueryCriteria);
-                objmap.put("url",fileurlList.get(0).getFileUrl());
+                if (null != fileurlList && !fileurlList.isEmpty()) {
+                    objmap.put("url", fileurlList.get(0).getFileUrl());
+                }
             }else if(Constants.WORKER_STATUS_FIAL == workstatus){
                 objmap.put("status","fail");
             }else {


### PR DESCRIPTION
### 背景
无此情况的非空判断
### 目标
增加非空判断
### 其他信息
无
