### PR TITLE
go-scheduler 模块实现模型数据文件url上传接口

### DIFF
--- a/gomicro/scheduler/internal/handler/routes.go
+++ b/gomicro/scheduler/internal/handler/routes.go
@@ -17,6 +17,11 @@ func RegisterHandlers(server *rest.Server, serverCtx *svc.ServiceContext) {
 				Path:    "/cpod/status",
 				Handler: CpodStatusHandler(serverCtx),
 			},
+			{
+				Method:  http.MethodPost,
+				Path:    "/info/upload_status",
+				Handler: UploadStatusHandler(serverCtx),
+			},
 		},
 	)
 }

--- a/gomicro/scheduler/internal/handler/upload_status_handler.go
+++ b/gomicro/scheduler/internal/handler/upload_status_handler.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/zeromicro/go-zero/rest/httpx"
+	"sxwl/3k/gomicro/scheduler/internal/logic"
+	"sxwl/3k/gomicro/scheduler/internal/svc"
+	"sxwl/3k/gomicro/scheduler/internal/types"
+)
+
+func UploadStatusHandler(svcCtx *svc.ServiceContext) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req types.ModelUrlReq
+		if err := httpx.Parse(r, &req); err != nil {
+			httpx.ErrorCtx(r.Context(), w, err)
+			return
+		}
+
+		l := logic.NewUploadStatusLogic(r.Context(), svcCtx)
+		resp, err := l.UploadStatus(&req)
+		if err != nil {
+			httpx.ErrorCtx(r.Context(), w, err)
+		} else {
+			httpx.OkJsonCtx(r.Context(), w, resp)
+		}
+	}
+}

--- a/gomicro/scheduler/internal/logic/upload_status_logic.go
+++ b/gomicro/scheduler/internal/logic/upload_status_logic.go
@@ -1,0 +1,47 @@
+package logic
+
+import (
+	"context"
+	"database/sql"
+	"sxwl/3k/gomicro/scheduler/internal/model"
+	"time"
+
+	"sxwl/3k/gomicro/scheduler/internal/svc"
+	"sxwl/3k/gomicro/scheduler/internal/types"
+
+	"github.com/zeromicro/go-zero/core/logx"
+)
+
+type UploadStatusLogic struct {
+	logx.Logger
+	ctx    context.Context
+	svcCtx *svc.ServiceContext
+}
+
+func NewUploadStatusLogic(ctx context.Context, svcCtx *svc.ServiceContext) *UploadStatusLogic {
+	return &UploadStatusLogic{
+		Logger: logx.WithContext(ctx),
+		ctx:    ctx,
+		svcCtx: svcCtx,
+	}
+}
+
+func (l *UploadStatusLogic) UploadStatus(req *types.ModelUrlReq) (resp *types.ModelUrlResp, err error) {
+	// todo: add your logic here and delete this line
+	FileURLModel := l.svcCtx.FileURLModel
+	for _, url := range req.DownloadUrls {
+		modeUrl := model.SysFileurl{
+			JobName:    req.JobName,
+			FileUrl:    sql.NullString{String: url, Valid: true},
+			CreateTime: sql.NullTime{Time: time.Now(), Valid: true},
+			UpdateTime: sql.NullTime{Time: time.Now(), Valid: true},
+		}
+		_, err := FileURLModel.Insert(l.ctx, &modeUrl)
+		if err != nil {
+			l.Logger.Errorf("modeUrl insert err=%s", err)
+			return nil, err
+		}
+		l.Logger.Infof("modeUrl insert sys_fileurl job_name=%s file_url=%s err=%s", req.JobName, url, err)
+	}
+	return
+}

--- a/gomicro/scheduler/internal/types/types.go
+++ b/gomicro/scheduler/internal/types/types.go
@@ -91,6 +91,15 @@ type CPODStatusResp struct {
 	Message string `json:"message"`
 }
 
+type ModelUrlReq struct {
+	DownloadUrls []string `json:"download_urls"`
+	JobName      string   `json:"job_name"`
+}
+
+type ModelUrlResp struct {
+	Message string `json:"message"`
+}
+
 type JobCallBackReq struct {
 	Status string `json:"status"`
 	URL    string `json:"url"`

--- a/gomicro/scheduler/scheduler.api
+++ b/gomicro/scheduler/scheduler.api
@@ -100,7 +100,17 @@ type CPODStatusResp {
 	Message string `json:"message"`
 }
 
+type ModelUrlReq {
+	DownloadUrls []string `json:"download_urls"`
+	JobName      string   `json:"job_name"`
+}
+type ModelUrlResp {
+	Message string `json:"message"`
+}
+
 service scheduler-api {
 	@handler CpodStatusHandler
 	post /cpod/status (CPODStatusReq) returns (CPODStatusResp)
+	@handler UploadStatusHandler
+	post /info/upload_status (ModelUrlReq) returns (ModelUrlResp)
 }

--- a/gomicro/scheduler/scheduler.api
+++ b/gomicro/scheduler/scheduler.api
@@ -104,6 +104,7 @@ type ModelUrlReq {
 	DownloadUrls []string `json:"download_urls"`
 	JobName      string   `json:"job_name"`
 }
+
 type ModelUrlResp {
 	Message string `json:"message"`
 }
@@ -111,6 +112,7 @@ type ModelUrlResp {
 service scheduler-api {
 	@handler CpodStatusHandler
 	post /cpod/status (CPODStatusReq) returns (CPODStatusResp)
+
 	@handler UploadStatusHandler
 	post /info/upload_status (ModelUrlReq) returns (ModelUrlResp)
 }


### PR DESCRIPTION
### 背景
之前java代码实现此功能
### 目标
目前放到go-scheduler模块实现
### 其他信息
无
